### PR TITLE
Add toggle to restore mode on file switch, add list of files to open read only

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2,14 +2,12 @@ import { MarkdownView, Notice, Plugin, PluginSettingTab, Setting } from 'obsidia
 
 
 interface ForceReadModePluginSettings {
-    targetFolderPaths: string[];  // Array of folder paths
-    targetFilePaths: string[];    // Array of exact file paths
+    targetPaths: string[];        // Array of file or folder paths
     restoreSourceMode: boolean;   // Whether to restore source mode for non-filtered files
 }
 
 const DEFAULT_SETTINGS: ForceReadModePluginSettings = {
-    targetFolderPaths: [],	// Array of folder paths is empty by default
-    targetFilePaths: [],     // Array of exact file paths is empty by default
+    targetPaths: [],         // Array of file or folder paths is empty by default
     restoreSourceMode: false  // Do not restore source mode by default for compatibility with previous versions
 };
 
@@ -73,14 +71,13 @@ export default class ForceReadModePlugin extends Plugin {
                 return;
             }
             
-            // Check if the file path exactly matches any of the target file paths
-            const isExactMatch = this.settings.targetFilePaths.includes(file.path);
+            // Check if the file matches any of the target paths (exact match or within folder)
+            const isTargetPath = this.settings.targetPaths.some(path => 
+                file.path === path || file.path.startsWith(path + '/')
+            );
             
-            // Check if the file is within any of the target folders or their subfolders
-            const isInTargetFolder = this.settings.targetFolderPaths.some(path => file.path.startsWith(path));
-            
-            // Apply read mode if the file matches either condition
-            if (isExactMatch || isInTargetFolder) {
+            // Apply read mode if the file matches
+            if (isTargetPath) {
                 // Force the view into preview (read mode)
                 leaf.setViewState({
                     ...leaf.getViewState(),
@@ -122,36 +119,23 @@ class ForceReadModeSettingTab extends PluginSettingTab {
 
         containerEl.empty();
 
-        // Add a setting for folder paths
+        // Add a setting for target paths
         new Setting(containerEl)
-            .setName('Target folder paths')
-            .setDesc('Specify the folder paths where markdown files should always open in read mode.')
+            .setName('Target paths')
+            .setDesc('Specify file or folder paths that should always open in read mode. For folders, all files within will be affected.')
             .addTextArea(text => text
-                .setPlaceholder('Enter folder paths, one per line')
-                .setValue(this.plugin.settings.targetFolderPaths.join('\n'))
+                .setPlaceholder('Enter file or folder paths, one per line')
+                .setValue(this.plugin.settings.targetPaths.join('\n'))
                 .onChange(async (value) => {
-                    // Update the settings with the new folder paths
-                    this.plugin.settings.targetFolderPaths = value.split('\n').map(path => path.trim()).filter(path => path.length > 0);
-                    await this.plugin.saveSettings();
-                }));
-                
-        // Add a setting for exact file paths
-        new Setting(containerEl)
-            .setName('Target file paths')
-            .setDesc('Specify exact file paths that should always open in read mode.')
-            .addTextArea(text => text
-                .setPlaceholder('Enter exact file paths, one per line')
-                .setValue(this.plugin.settings.targetFilePaths.join('\n'))
-                .onChange(async (value) => {
-                    // Update the settings with the new exact file paths
-                    this.plugin.settings.targetFilePaths = value.split('\n').map(path => path.trim()).filter(path => path.length > 0);
+                    // Update the settings with the new paths
+                    this.plugin.settings.targetPaths = value.split('\n').map(path => path.trim()).filter(path => path.length > 0);
                     await this.plugin.saveSettings();
                 }));
                 
         // Add toggle for restoring source mode
         new Setting(containerEl)
             .setName('Restore Source Mode')
-            .setDesc('When enabled, opening files not in your target folders/paths will automatically switch to edit mode again.')
+            .setDesc('When enabled, opening files not in your target paths will automatically switch to edit mode again.')
             .addToggle(toggle => toggle
                 .setValue(this.plugin.settings.restoreSourceMode)
                 .onChange(async (value) => {

--- a/main.ts
+++ b/main.ts
@@ -1,18 +1,20 @@
-import { Plugin, MarkdownView, Notice, PluginSettingTab, Setting } from 'obsidian';
+import { MarkdownView, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
 
 
 interface ForceReadModePluginSettings {
     targetFolderPaths: string[];  // Array of folder paths
+    targetFilePaths: string[];    // Array of exact file paths
 }
 
 const DEFAULT_SETTINGS: ForceReadModePluginSettings = {
-    targetFolderPaths: [ ]	// Array of folder paths is empty by default
+    targetFolderPaths: [],	// Array of folder paths is empty by default
+    targetFilePaths: []     // Array of exact file paths is empty by default
 };
 
 
 export default class ForceReadModePlugin extends Plugin {
     settings: ForceReadModePluginSettings;
-    isEnabled: boolean = true;
+    isEnabled = true;
 
     // Plugin initialization
     async onload() {
@@ -68,19 +70,21 @@ export default class ForceReadModePlugin extends Plugin {
             if (!file) {
                 return;
             }
-        
+            
+            // Check if the file path exactly matches any of the target file paths
+            const isExactMatch = this.settings.targetFilePaths.includes(file.path);
+            
             // Check if the file is within any of the target folders or their subfolders
             const isInTargetFolder = this.settings.targetFolderPaths.some(path => file.path.startsWith(path));
             
-            if (!isInTargetFolder) {
-                return;
+            // Apply read mode if the file matches either condition
+            if (isExactMatch || isInTargetFolder) {
+                // Force the view into preview (read mode)
+                leaf.setViewState({
+                    ...leaf.getViewState(),
+                    state: { mode: 'preview' } // Force preview (read mode)
+                });
             }
-        
-            // Force the view into preview (read mode)
-            leaf.setViewState({
-                ...leaf.getViewState(),
-                state: { mode: 'preview' } // Force preview (read mode)
-            });
         });        
     }
 
@@ -118,6 +122,19 @@ class ForceReadModeSettingTab extends PluginSettingTab {
                 .onChange(async (value) => {
                     // Update the settings with the new folder paths
                     this.plugin.settings.targetFolderPaths = value.split('\n').map(path => path.trim()).filter(path => path.length > 0);
+                    await this.plugin.saveSettings();
+                }));
+                
+        // Add a setting for exact file paths
+        new Setting(containerEl)
+            .setName('Target file paths')
+            .setDesc('Specify exact file paths that should always open in read mode.')
+            .addTextArea(text => text
+                .setPlaceholder('Enter exact file paths, one per line')
+                .setValue(this.plugin.settings.targetFilePaths.join('\n'))
+                .onChange(async (value) => {
+                    // Update the settings with the new exact file paths
+                    this.plugin.settings.targetFilePaths = value.split('\n').map(path => path.trim()).filter(path => path.length > 0);
                     await this.plugin.saveSettings();
                 }));
     }


### PR DESCRIPTION
Hi, nice plugin! For me, it missed two options though:
1. The option to switch back from read-only to edit mode after switching to a non-listed file/folder
1. The option to list specific files that should be read-only, not just folders.

This PR implements this:
<img width="990" alt="image" src="https://github.com/user-attachments/assets/37dc8b78-2774-47c3-ac6d-e780a1ccdbdc" />


I am unsure what to do with the version, should I bump this?